### PR TITLE
bug fix cacheFolder Proxy Class

### DIFF
--- a/swiftshadow/classes.py
+++ b/swiftshadow/classes.py
@@ -48,7 +48,7 @@ class Proxy:
         self.maxProxies = maxProxies
         self.autoRotate = autoRotate
         self.cachePeriod = cachePeriod
-        if cacheFolder != "":
+        if cacheFolder == "":
             self.cacheFilePath = ".swiftshadow.json"
         else:
             self.cacheFilePath = f"{cacheFolder}/.swiftshadow.json"


### PR DESCRIPTION
changed "!=" to "==" in line 51 so if you want to pass a cacheFolder argument to the Proxy Class (especially relevant for AWS Lambda users , e.g. "/tmp" ) it will now set this as a path for the cache