### PR TITLE
Update providers.py

### DIFF
--- a/swiftshadow/providers.py
+++ b/swiftshadow/providers.py
@@ -11,7 +11,7 @@ def Monosans(max, countries=[],protocol="http"):
         if proxy['protocol'] == protocol:
             if len(countries) != 0 and proxy['geolocation']['country']['iso_code'] not in countries:
                 continue
-            proxy = [f'{proxy['host']}:{proxy['port']}',proxy['protocol']]
+            proxy = [f'{proxy["host"]}:{proxy["port"]}',proxy['protocol']]
             if checkProxy(proxy):
                 results.append(proxy)
                 count += 1


### PR DESCRIPTION
Fixed the issue: SyntaxError : f-string: unmatched '['

Problem of f-string unable to take single quotes is fixed with replacing double quotes.

Previous Version : proxy = [f'{proxy['host']}:{proxy['port']}',proxy['protocol']] 

Current Change: proxy = [f'{proxy["host"]}:{proxy["port"]}',proxy['protocol']]

Place of Error Occurence:

from swiftshadow import QuickProxy
from requests import get

proxy = QuickProxy()
resp = get('https://checkip.amazonaws.com', proxies={proxy[1]: proxy[0]})
print(resp.text)