### PR TITLE
Clarify error message for https and fixed typo

### DIFF
--- a/swiftshadow/classes.py
+++ b/swiftshadow/classes.py
@@ -170,7 +170,9 @@ class ProxyInterface:
                 break
 
         if len(self.proxies) == 0:
-            raise ValueError("No proxies where found for the current filter settings.")
+            if self.protocol == "https":
+                raise ValueError("No proxies were found for the current filter settings. Tip: https proxies can be rare; recommend setting protocol to http")
+            raise ValueError("No proxies were found for the current filter settings.")
 
         async with aiofiles.open(
             self.cacheFolderPath.joinpath("swiftshadow.pickle"), "wb+"
@@ -233,7 +235,7 @@ class ProxyInterface:
                 break
 
         if len(self.proxies) == 0:
-            raise ValueError("No proxies where found for the current filter settings.")
+            raise ValueError("No proxies were found for the current filter settings.")
 
         with open(
             self.cacheFolderPath.joinpath("swiftshadow.pickle"), "wb+"


### PR DESCRIPTION
Per Issue #40 , https proxies can be rare.
Added additional text to error message if the protocol is set to https to increase user friendliness.

Also corrected minor typo in the error message
"where" (incorrect) vs "were" (correct)

Thanks for creating this great library and your consideration of my PR